### PR TITLE
Add interval-based evaluation loop

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,26 @@
 using AlarmaDisparadorCore.Services;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.IO;
+using System.Threading;
 
+var config = new ConfigurationBuilder()
+    .SetBasePath(Directory.GetCurrentDirectory())
+    .AddJsonFile("appsettings.json")
+    .Build();
+
+var intervaloSegundos = 60;
+if (int.TryParse(config["IntervaloSegundos"], out var parsedIntervalo))
+{
+    intervaloSegundos = parsedIntervalo;
+}
 var evaluador = new Evaluador();
-evaluador.EvaluarReglas();
+
+while (true)
+{
+    Console.WriteLine($"Inicio de evaluación: {DateTime.Now:O}");
+    evaluador.EvaluarReglas();
+    Console.WriteLine($"Fin de evaluación: {DateTime.Now:O}");
+    Thread.Sleep(TimeSpan.FromSeconds(intervaloSegundos));
+}
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "IntervaloSegundos": 60,
   "ConnectionStrings": {
     "DefaultConnection": "Server=DESKTOP-2Q6GEKL\\SQLEXPRESS;Database=scada;User Id=sa;Password=SqlPassword1234$;Encrypt=False;MultipleActiveResultSets=True"
   }


### PR DESCRIPTION
## Summary
- run evaluation repeatedly at a configurable interval from `appsettings.json`
- log start and end of each execution cycle
- parse interval setting without `GetValue` extension to avoid missing package

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689cde3c049c832aa01d7795c24fd6de