### PR TITLE
Reintroducir intervalo de disparo y eliminar validación horaria

### DIFF
--- a/Models/ReglaAlarma.cs
+++ b/Models/ReglaAlarma.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace AlarmaDisparadorCore.Models
 {
     public class ReglaAlarma
@@ -8,5 +10,10 @@ namespace AlarmaDisparadorCore.Models
         public string Mensaje { get; set; }
         public bool Activo { get; set; }
         public bool EnCurso { get; set; } = false;
+        public bool EnviarCorreo { get; set; }
+        public string EmailDestino { get; set; }
+        public TimeSpan? HoraInicio { get; set; }
+        public TimeSpan? HoraFin { get; set; }
+        public int IntervaloMin { get; set; }
     }
 }

--- a/Services/ReglaRepository.cs
+++ b/Services/ReglaRepository.cs
@@ -1,0 +1,43 @@
+using AlarmaDisparadorCore.Models;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Data.SqlClient;
+using System.IO;
+
+namespace AlarmaDisparadorCore.Services
+{
+    public class ReglaRepository
+    {
+        private readonly string _connectionString;
+
+        public ReglaRepository()
+        {
+            var config = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json")
+                .Build();
+
+            _connectionString = config.GetConnectionString("DefaultConnection");
+        }
+
+        public void ActualizarRegla(ReglaAlarma regla)
+        {
+            const string sqlRule = @"UPDATE dbo.reglas_alarma SET nombre = @Name, operador = @LogicOperator, mensaje = @Message, activo = @IsActive, enviar_correo = @SendEmail, email_destino = @EmailTo, hora_inicio = @TimeStart, hora_fin = @TimeEnd, intervalo_min = @Interval WHERE id_regla = @Id";
+
+            using var conn = new SqlConnection(_connectionString);
+            conn.Open();
+            using var cmd = new SqlCommand(sqlRule, conn);
+            cmd.Parameters.AddWithValue("@Id", regla.Id);
+            cmd.Parameters.AddWithValue("@Name", regla.Nombre);
+            cmd.Parameters.AddWithValue("@LogicOperator", (object?)regla.Operador ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@Message", (object?)regla.Mensaje ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@IsActive", regla.Activo);
+            cmd.Parameters.AddWithValue("@SendEmail", regla.EnviarCorreo);
+            cmd.Parameters.AddWithValue("@EmailTo", (object?)regla.EmailDestino ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@TimeStart", (object?)regla.HoraInicio ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@TimeEnd", (object?)regla.HoraFin ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@Interval", regla.IntervaloMin);
+            cmd.ExecuteNonQuery();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- agrega `IntervaloMin` al modelo y al repositorio de reglas
- evalúa reglas sólo por condiciones y respeta el intervalo entre disparos

## Testing
- `dotnet build` (falla: command not found)
- `apt-get update` (falla: 403 Forbidden)
- `apt-get install -y dotnet-sdk-8.0` (falla: Unable to locate package)


------
https://chatgpt.com/codex/tasks/task_e_68af5bc9f374832a8013747a0d7d7bdf