### PR TITLE
Renombrar intervalo y eliminar horas

### DIFF
--- a/Models/ReglaAlarma.cs
+++ b/Models/ReglaAlarma.cs
@@ -12,8 +12,6 @@ namespace AlarmaDisparadorCore.Models
         public bool EnCurso { get; set; } = false;
         public bool EnviarCorreo { get; set; }
         public string EmailDestino { get; set; }
-        public TimeSpan? HoraInicio { get; set; }
-        public TimeSpan? HoraFin { get; set; }
-        public int IntervaloMin { get; set; }
+        public int IntervaloMinuto { get; set; }
     }
 }

--- a/Services/Evaluador.cs
+++ b/Services/Evaluador.cs
@@ -124,7 +124,7 @@ namespace AlarmaDisparadorCore.Services
             try
             {
                 conn.Open();
-                using var cmd = new SqlCommand("SELECT id_regla, nombre, operador, mensaje, activo, en_curso, enviar_correo, email_destino, hora_inicio, hora_fin, intervalo_min FROM reglas_alarma", conn);
+                using var cmd = new SqlCommand("SELECT id_regla, nombre, operador, mensaje, activo, en_curso, enviar_correo, email_destino, intervalo_minuto FROM reglas_alarma", conn);
                 using var reader = cmd.ExecuteReader();
                 while (reader.Read())
                 {
@@ -138,9 +138,7 @@ namespace AlarmaDisparadorCore.Services
                         EnCurso = reader.IsDBNull(5) ? false : reader.GetBoolean(5),
                         EnviarCorreo = reader.IsDBNull(6) ? false : reader.GetBoolean(6),
                         EmailDestino = reader.IsDBNull(7) ? null : reader.GetString(7),
-                        HoraInicio = reader.IsDBNull(8) ? null : reader.GetTimeSpan(8),
-                        HoraFin = reader.IsDBNull(9) ? null : reader.GetTimeSpan(9),
-                        IntervaloMin = reader.IsDBNull(10) ? 0 : Convert.ToInt32(reader.GetValue(10))
+                        IntervaloMinuto = reader.IsDBNull(8) ? 0 : Convert.ToInt32(reader.GetValue(8))
                     });
                 }
             }
@@ -235,14 +233,14 @@ namespace AlarmaDisparadorCore.Services
 
         private bool DebeDisparar(ReglaAlarma regla)
         {
-            if (regla.IntervaloMin <= 0)
+            if (regla.IntervaloMinuto <= 0)
                 return true;
 
             var ultimo = ObtenerUltimoDisparo(regla.Id);
             if (ultimo == null)
                 return true;
 
-            return (DateTime.Now - ultimo.Value).TotalMinutes >= regla.IntervaloMin;
+            return (DateTime.Now - ultimo.Value).TotalMinutes >= regla.IntervaloMinuto;
         }
 
         private DateTime? ObtenerUltimoDisparo(int idRegla)

--- a/Services/ReglaRepository.cs
+++ b/Services/ReglaRepository.cs
@@ -22,7 +22,7 @@ namespace AlarmaDisparadorCore.Services
 
         public void ActualizarRegla(ReglaAlarma regla)
         {
-            const string sqlRule = @"UPDATE dbo.reglas_alarma SET nombre = @Name, operador = @LogicOperator, mensaje = @Message, activo = @IsActive, enviar_correo = @SendEmail, email_destino = @EmailTo, hora_inicio = @TimeStart, hora_fin = @TimeEnd, intervalo_min = @Interval WHERE id_regla = @Id";
+            const string sqlRule = @"UPDATE dbo.reglas_alarma SET nombre = @Name, operador = @LogicOperator, mensaje = @Message, activo = @IsActive, enviar_correo = @SendEmail, email_destino = @EmailTo, intervalo_minuto = @IntervaloMinuto WHERE id_regla = @Id";
 
             using var conn = new SqlConnection(_connectionString);
             conn.Open();
@@ -34,9 +34,7 @@ namespace AlarmaDisparadorCore.Services
             cmd.Parameters.AddWithValue("@IsActive", regla.Activo);
             cmd.Parameters.AddWithValue("@SendEmail", regla.EnviarCorreo);
             cmd.Parameters.AddWithValue("@EmailTo", (object?)regla.EmailDestino ?? DBNull.Value);
-            cmd.Parameters.AddWithValue("@TimeStart", (object?)regla.HoraInicio ?? DBNull.Value);
-            cmd.Parameters.AddWithValue("@TimeEnd", (object?)regla.HoraFin ?? DBNull.Value);
-            cmd.Parameters.AddWithValue("@Interval", regla.IntervaloMin);
+            cmd.Parameters.AddWithValue("@IntervaloMinuto", regla.IntervaloMinuto);
             cmd.ExecuteNonQuery();
         }
     }


### PR DESCRIPTION
## Resumen
- Reemplazo de `intervalo_min` por `intervalo_minuto` en modelos, repositorio y evaluador.
- Eliminación de campos de horas no utilizados en la lógica de reglas.

## Testing
- `dotnet build` *(falla: command not found)*
- `apt-get update` *(falla: 403 Forbidden al intentar descargar paquetes)*

------
https://chatgpt.com/codex/tasks/task_e_68b09e17e934832aa37fdb1d17e154ca