### PR TITLE
Fix table name for alarm logs

### DIFF
--- a/Services/Evaluador.cs
+++ b/Services/Evaluador.cs
@@ -249,7 +249,7 @@ namespace AlarmaDisparadorCore.Services
             try
             {
                 conn.Open();
-                using var cmd = new SqlCommand("SELECT TOP 1 timestamp FROM disparos_alarma WHERE id_regla = @id ORDER BY timestamp DESC", conn);
+                using var cmd = new SqlCommand("SELECT TOP 1 timestamp FROM disparos_alarmas WHERE id_regla = @id ORDER BY timestamp DESC", conn);
                 cmd.Parameters.AddWithValue("@id", idRegla);
                 var result = cmd.ExecuteScalar();
                 if (result == null || result == DBNull.Value)
@@ -289,7 +289,7 @@ namespace AlarmaDisparadorCore.Services
             try
             {
                 conn.Open();
-                using var cmd = new SqlCommand("INSERT INTO disparos_alarma (id_regla, mensaje, timestamp) VALUES (@id, @msg, @ts)", conn);
+                using var cmd = new SqlCommand("INSERT INTO disparos_alarmas (id_regla, mensaje, timestamp) VALUES (@id, @msg, @ts)", conn);
                 cmd.Parameters.AddWithValue("@id", regla.Id);
                 cmd.Parameters.AddWithValue("@msg", regla.Mensaje ?? "");
                 cmd.Parameters.AddWithValue("@ts", DateTime.Now);


### PR DESCRIPTION
## Summary
- use `disparos_alarmas` table in evaluator queries

## Testing
- `dotnet build` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b0abfd2404832aae2047cf2803c999