### PR TITLE
Fix alarm trigger logic to respect en_curso and interval

### DIFF
--- a/Services/Evaluador.cs
+++ b/Services/Evaluador.cs
@@ -233,8 +233,11 @@ namespace AlarmaDisparadorCore.Services
 
         private bool DebeDisparar(ReglaAlarma regla)
         {
-            if (regla.IntervaloMinutos <= 0)
+            if (!regla.EnCurso)
                 return true;
+
+            if (regla.IntervaloMinutos <= 0)
+                return false;
 
             var ultimo = ObtenerUltimoDisparo(regla.Id);
             if (ultimo == null)


### PR DESCRIPTION
## Summary
- Avoid repeated alarm firing while the rule is in progress and interval is zero
- Reset interval checks when the rule is not in progress

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b49f3fb8832ab7c426965c06b1ba